### PR TITLE
refactor: replace JWT key/secret with INWORLD_API_KEY (Basic Base64)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,7 +1,5 @@
-# Inworld Runtime API Key
-INWORLD_KEY=
-# Inworld Runtime API Secret
-INWORLD_SECRET=
+# Paste the Basic (Base64) credential from https://platform.inworld.ai/api-keys
+INWORLD_API_KEY=
 # Inworld workspace in the form of "workspaces/<workspace_id>"
 INWORLD_WORKSPACE=workspaces/default
 

--- a/.env.template
+++ b/.env.template
@@ -1,4 +1,4 @@
-# Paste the Basic (Base64) credential from https://platform.inworld.ai/api-keys
+# Inworld API Key
 INWORLD_API_KEY=
 # Inworld workspace in the form of "workspaces/<workspace_id>"
 INWORLD_WORKSPACE=workspaces/default

--- a/.env.template
+++ b/.env.template
@@ -1,7 +1,5 @@
 # Inworld API Key
 INWORLD_API_KEY=
-# Inworld workspace in the form of "workspaces/<workspace_id>"
-INWORLD_WORKSPACE=workspaces/default
 
 INWORLD_HOST=api.inworld.ai
 INWORLD_ENGINE_HOST=api-engine.inworld.ai

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The entire implementation is in `src/index.ts`, making it easy to understand and
 
 2. Create a `.env` file with your Inworld API key:
    ```
-   INWORLD_API_KEY=<paste the Basic (Base64) value from your Studio API Keys panel>
+   INWORLD_API_KEY=your_api_key_here
    INWORLD_HOST=api.inworld.ai
    INWORLD_WORKSPACE=workspaces/your-workspace-id
    ```

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ The entire implementation is in `src/index.ts`, making it easy to understand and
    ```
    INWORLD_API_KEY=your_api_key_here
    INWORLD_HOST=api.inworld.ai
-   INWORLD_WORKSPACE=workspaces/your-workspace-id
    ```
 
 ## Build
@@ -105,7 +104,7 @@ const response = await axios.post<JwtTokenResponse>(
   `https://${host}/auth/v1/tokens/token:generate`,
   {
     key: apiKey,
-    resources: [workspaceName]
+    resources: []
   },
   {
     headers: {
@@ -170,27 +169,25 @@ If you receive a 403 Forbidden error with "invalid authorization signature", con
 
 1. **Check API Credentials**: Ensure your API key and secret are valid and have not expired.
 
-2. **Workspace Name**: The correct format for the workspace name is typically: `workspaces/your-workspace-id`. This should be set in your `.env` file.
-
-3. **API Endpoint**: Verify the token generation endpoint with Inworld's latest documentation. The current implementation uses:
+2. **API Endpoint**: Verify the token generation endpoint with Inworld's latest documentation. The current implementation uses:
    ```
    https://api.inworld.ai/auth/v1/tokens/token:generate
    ```
 
-4. **Authorization Header**: The format of the authorization header is:
+3. **Authorization Header**: The format of the authorization header is:
    ```
    IW1-HMAC-SHA256 ApiKey=your_key,DateTime=YYYYMMDDHHMMSS,Nonce=random_nonce,Signature=signature
    ```
 
-5. **Request Body**: The implementation includes the key and resources in the request body:
+4. **Request Body**: The implementation includes the key in the request body. `resources` is left empty so the token defaults to the workspace the API key belongs to:
    ```json
    {
      "key": "your_api_key",
-     "resources": ["workspaces/your-workspace-id"]
+     "resources": []
    }
    ```
 
-6. **Headers Format**: While HTTP headers are case-insensitive according to the HTTP specification, it's standard practice to use Pascal-case format in documentation. In code, they are typically represented as:
+5. **Headers Format**: While HTTP headers are case-insensitive according to the HTTP specification, it's standard practice to use Pascal-case format in documentation. In code, they are typically represented as:
    ```
    Authorization: IW1-HMAC-SHA256 ...
    Host: api.inworld.ai

--- a/README.md
+++ b/README.md
@@ -28,10 +28,9 @@ The entire implementation is in `src/index.ts`, making it easy to understand and
    npm install
    ```
 
-2. Create a `.env` file with your Inworld API credentials:
+2. Create a `.env` file with your Inworld API key:
    ```
-   INWORLD_KEY=your_jwt_key_here
-   INWORLD_SECRET=your_jwt_secret_here
+   INWORLD_API_KEY=<paste the Basic (Base64) value from your Studio API Keys panel>
    INWORLD_HOST=api.inworld.ai
    INWORLD_WORKSPACE=workspaces/your-workspace-id
    ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,23 @@ interface ApiKey {
   secret: string;
 }
 
+// Resolves the API key + secret pair. Prefers INWORLD_API_KEY (the Basic
+// Base64 credential from the Studio API Keys panel); falls back to
+// INWORLD_KEY + INWORLD_SECRET for older .env files.
+function resolveApiKey(): ApiKey {
+  const basic = (process.env.INWORLD_API_KEY || '').trim();
+  if (basic) {
+    const decoded = Buffer.from(basic, 'base64').toString('utf8');
+    const idx = decoded.indexOf(':');
+    if (idx <= 0) throw new Error('INWORLD_API_KEY must be base64 of "<key>:<secret>"');
+    return { key: decoded.slice(0, idx), secret: decoded.slice(idx + 1) };
+  }
+  return {
+    key: process.env.INWORLD_KEY || '',
+    secret: process.env.INWORLD_SECRET || '',
+  };
+}
+
 /**
  * JWT Token Response from Inworld API
  * 
@@ -88,11 +105,8 @@ function getAuthorization({host, apiKey, engineHost}: { host: string; apiKey: Ap
 }
 
 function generateAuthHeader(): string {
-  const apiKey: ApiKey = {
-    key: process.env.INWORLD_KEY || '',
-    secret: process.env.INWORLD_SECRET || '',
-  };
-  
+  const apiKey: ApiKey = resolveApiKey();
+
   const host = process.env.INWORLD_HOST || 'api.inworld.ai';
     const engineHost = process.env.INWORLD_ENGINE_HOST || 'api-engine.inworld.ai';
     return getAuthorization({host, apiKey, engineHost});
@@ -102,7 +116,7 @@ function generateAuthHeader(): string {
 async function getJwtToken(): Promise<JwtTokenResponse> {
   const host = process.env.INWORLD_HOST || 'api.inworld.ai';
   const authHeader = generateAuthHeader();
-  const apiKey = process.env.INWORLD_KEY || '';
+  const apiKey = resolveApiKey().key;
   const workspaceName = process.env.INWORLD_WORKSPACE || 'workspaces/default-workspace';
   
   try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,14 +119,13 @@ async function getJwtToken(): Promise<JwtTokenResponse> {
   const host = process.env.INWORLD_HOST || 'api.inworld.ai';
   const authHeader = generateAuthHeader();
   const apiKey = resolveApiKey().key;
-  const workspaceName = process.env.INWORLD_WORKSPACE || 'workspaces/default-workspace';
-  
+
   try {
     const response = await axios.post<JwtTokenResponse>(
       `https://${host}/auth/v1/tokens/token:generate`,
       {
         key: apiKey,
-        resources: [workspaceName]
+        resources: []
       },
       {
         headers: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,13 +37,15 @@ function resolveApiKey(): ApiKey {
   if (basic) {
     const decoded = Buffer.from(basic, 'base64').toString('utf8');
     const idx = decoded.indexOf(':');
-    if (idx <= 0) throw new Error('INWORLD_API_KEY must be base64 of "<key>:<secret>"');
-    return { key: decoded.slice(0, idx), secret: decoded.slice(idx + 1) };
+    const key = idx > 0 ? decoded.slice(0, idx) : '';
+    const secret = idx > 0 ? decoded.slice(idx + 1) : '';
+    if (!key || !secret) throw new Error('INWORLD_API_KEY must be base64 of "<key>:<secret>" (both parts non-empty)');
+    return { key, secret };
   }
-  return {
-    key: process.env.INWORLD_KEY || '',
-    secret: process.env.INWORLD_SECRET || '',
-  };
+  const key = (process.env.INWORLD_KEY || '').trim();
+  const secret = (process.env.INWORLD_SECRET || '').trim();
+  if (!key || !secret) throw new Error('Set INWORLD_API_KEY (Basic Base64 from the Studio API Keys panel) or both INWORLD_KEY and INWORLD_SECRET');
+  return { key, secret };
 }
 
 /**


### PR DESCRIPTION
## Description

This PR removes the sample's reliance on the JWT Key and JWT Secret labels that are being hidden from the Studio API Keys panel 

## Testing

- [x] `yarn build` passes.
- [ ] End-to-end: set `INWORLD_API_KEY` to a known-good Basic Base64 from a dev workspace, run `yarn start`, verify a valid JWT comes back.
- [ ] Backward-compat: with only `INWORLD_KEY` + `INWORLD_SECRET` set, `yarn start` still produces a valid JWT.
- [ ] Error path: with `INWORLD_API_KEY=garbage` or no env vars set, the sample exits with a clear message.